### PR TITLE
Update Dockerfile to install libgl1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.11-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    libgl1-mesa-glx \
+    libgl1 \
     libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
基础 apt 源不再包含 libgl1-mesa-glx ，现将其更改为 libgl1。
另外，初次提交PR，误直接往main提交了，很抱歉(╯︵╰,)